### PR TITLE
fix deprecated module at 3.10

### DIFF
--- a/ucloud/core/exc/_exc.py
+++ b/ucloud/core/exc/_exc.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Iterable
 
 from ucloud.core.utils import compat
 
@@ -81,7 +81,7 @@ class ValidationException(UCloudException):
     def __init__(self, e=None):
         if isinstance(e, compat.string_types):
             self.errors = [e]
-        elif isinstance(e, collections.Iterable):
+        elif isinstance(e, Iterable):
             self.errors = e or []
         else:
             self.errors = [e]

--- a/ucloud/core/typesystem/fields.py
+++ b/ucloud/core/typesystem/fields.py
@@ -1,6 +1,6 @@
 import base64
 import typing
-import collections
+from collections.abc import Iterable
 
 from ucloud.core.typesystem import abstract
 from ucloud.core.exc import ValidationException
@@ -25,7 +25,7 @@ class List(abstract.Field):
         self.item = item
 
     def dumps(self, value, name=None, **kwargs):
-        if not isinstance(value, collections.Iterable):
+        if not isinstance(value, Iterable):
             raise ValidationException(
                 "invalid field {}, expect list, got {}".format(
                     name, type(value)
@@ -48,7 +48,7 @@ class List(abstract.Field):
         return values
 
     def loads(self, value, name=None, **kwargs):
-        if not isinstance(value, collections.Iterable):
+        if not isinstance(value, Iterable):
             raise ValidationException(
                 "invalid field {}, expect list, got {}".format(
                     name, type(value)


### PR DESCRIPTION
BUG FIXES:

- Fix deprecated class: `collections.Iterable` to `collections.abc.Iterable` at 3.10
