### PR TITLE
fix(test): replace collections.Callable, removed in Python 3.10

### DIFF
--- a/tests/test_unit/test_core/test_client.py
+++ b/tests/test_unit/test_core/test_client.py
@@ -3,7 +3,6 @@ import uuid
 
 import pytest
 import logging
-import collections
 import requests_mock
 
 from ucloud.client import Client
@@ -102,5 +101,5 @@ def test_client_try_import(client):
             continue
 
         client_factory = getattr(client, name)
-        if isinstance(client_factory, collections.Callable):
+        if callable(client_factory):
             print(client_factory())


### PR DESCRIPTION
## Problem

`tests/test_unit/test_core/test_client.py::test_client_try_import` uses:

```python
if isinstance(client_factory, collections.Callable):
```

`collections.Callable` has been an alias for `collections.abc.Callable` since Python 3.3 and was **removed in 3.10**, so the test raises:

```
E   AttributeError: module 'collections' has no attribute 'Callable'
tests/test_unit/test_core/test_client.py:105: AttributeError
```

The suite therefore only passes on Python ≤ 3.9.

## Why it went unnoticed

`.travis.yml` tests 3.5 / 3.6 / 3.7 — all below the cutoff. And Travis has not run on this repo for a long time, so nothing has exercised the suite on a modern interpreter.

## Fix

Use the builtin `callable()`.

Same semantics — `collections.abc.Callable.__subclasshook__` just checks for `__call__` — and it lets the now-unused `collections` import go, rather than keeping an import around for a single predicate.

```diff
-import collections
...
-        if isinstance(client_factory, collections.Callable):
+        if callable(client_factory):
```

## Verified

Python 3.11.9, `make test-cov`:

| | result |
|---|---|
| before | **1 failed**, 47 passed, 37 skipped |
| after | **48 passed**, 37 skipped |

`make lint` (flake8) and `python -m compileall ucloud` both stay at exit 0.
